### PR TITLE
Backend code coverage

### DIFF
--- a/backend/api/meta_attribute.py
+++ b/backend/api/meta_attribute.py
@@ -33,7 +33,7 @@ class MetaAttributeHandler(Handler):
             'ID': meta.id
         }
 
-    @requires_validation(_assert_attribute_does_not_exist, with_route_params=True)
+    @requires_validation(assert_attribute_does_not_exist(MetaAttribute), with_route_params=True)
     @requires_validation(Schema({'name': non_empty_string}))
     def put(self, entity_type_id, ident):
         data = self.request.data

--- a/backend/api/validators.py
+++ b/backend/api/validators.py
@@ -1,5 +1,8 @@
 from voluptuous import truth, message
+
+from database.helpers import get_all
 from database.model import Session
+
 
 @message('expected a non-empty string')
 @truth

--- a/backend/database/helpers.py
+++ b/backend/database/helpers.py
@@ -11,6 +11,6 @@ def get_one(session, cls, **kwargs):
         exception_cls = HTTP_404
     result = session.query(cls).filter_by(delete_ts=None, **kwargs).all()
     if len(result) != 1:
-        raise exception_cls("{} with ID: {} not found".format(cls.__name__, kwargs["id"]))
+        raise exception_cls("{} with ID: {} not found".format(cls.__name__, kwargs.get('id', '?')))
     else:
         return result[0]

--- a/backend/database/model.py
+++ b/backend/database/model.py
@@ -129,7 +129,7 @@ class Entity(Base):
     last_data_fetch_ts = Column(Integer, nullable=False, default=0)
     delete_ts = Column(Integer, nullable=True, default=None)
 
-    entity_type = relationship('EntityType', primaryjoin='Entity.entity_type_id_fk == EntityType.id')
+    entity_type = relationship('EntityType', backref='nodes', primaryjoin='Entity.entity_type_id_fk == EntityType.id')
     parent = relationship('Entity', backref='children', remote_side='Entity.id',
                           primaryjoin='Entity.parent_id_fk == Entity.id')
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,7 +2,8 @@ sqlalchemy
 psycopg2
 influxdb
 tornado
-pycnic
+git+https://github.com/nullism/pycnic.git
 voluptuous
 nose
+coverage
 alembic

--- a/backend/sensors/parser.py
+++ b/backend/sensors/parser.py
@@ -14,11 +14,14 @@ def convert_timestamp(timestamp):
 class FileParser(PointSource):
     def __init__(self, entity_id, filename):
         self._entity = get_one(Session(), Entity, id=entity_id)
-        self._file = open(filename)
+        self._filename = filename
 
     def get_values(self) -> Iterable[dict]:
         result = []
-        for line in self._file:
+        with open(self._filename) as file:
+            lines = file.readlines()
+
+        for line in lines:
             fields = line[:-1].split(',')
             result.append({
                 'timestamp': convert_timestamp(fields[0]),

--- a/backend/tests/test_api_object_deleters.py
+++ b/backend/tests/test_api_object_deleters.py
@@ -1,0 +1,155 @@
+from unittest.mock import patch
+
+from pycnic.errors import HTTP_404
+
+from api.entity_type import EntityTypeHandler
+from api.meta_attribute import MetaAttributeHandler
+from api.series_attribute import SeriesAttributeHandler
+from api.tag_attribute import TagAttributeHandler
+from api.tree import EntityHandler
+from database.helpers import get_all, get_one
+from database.model import EntityType, TagAttribute, SeriesAttribute, MetaAttribute, Entity, EntityMeta, EntityTag
+from .test_utils import AbstractTestWithDatabase, Session, get_handler
+
+
+@patch('api.entity_type.Session', new=Session)
+class TestEntityTypeDeleteHandler(AbstractTestWithDatabase):
+    def setUp(self):
+        super().setUp()
+        # create entity types
+        with patch('api.entity_type.Session', new=Session):
+            get_handler(EntityTypeHandler, {'name': 'foo', 'tags': ['t'], 'series': ['s'], 'meta': ['m']}).post()
+            get_handler(EntityTypeHandler, {'name': 'foo', 'tags': ['t2'], 'series': [], 'meta': ['m2']}).post()
+        # create nodes
+        with patch('api.tree.Session', new=Session):
+            get_handler(EntityHandler, {'parent_id': None, 'entity_type_id': 1, 'tag_1': 'tag_val',
+                                        'meta_1': 'meta_val'}).post()
+            get_handler(EntityHandler, {'parent_id': None, 'entity_type_id': 2, 'tag_2': 'tag_val',
+                                        'meta_2': 'meta_val'}).post()
+
+    def test_delete_removes_object_and_dependants(self):
+        result = get_handler(EntityTypeHandler).delete(1)
+        self.assertEqual({'success': True}, result)
+        self.assertEqual(len(get_all(Session(), EntityType)), 1)
+        self.assertEqual(get_one(Session(), EntityType).id, 2)
+        self.assertEqual(len(get_all(Session(), TagAttribute)), 1)
+        self.assertEqual(len(get_all(Session(), SeriesAttribute)), 0)
+        self.assertEqual(len(get_all(Session(), MetaAttribute)), 1)
+        self.assertEqual(len(get_all(Session(), Entity)), 1)
+
+    def test_invalid_request_raises(self):
+        with self.assertRaises(HTTP_404):
+            get_handler(EntityTypeHandler).delete(10)  # non existing entity type
+
+
+@patch('api.meta_attribute.Session', new=Session)
+class TestMetaAttributeDeleteHandler(AbstractTestWithDatabase):
+    def setUp(self):
+        super().setUp()
+        # create entity type
+        with patch('api.entity_type.Session', new=Session):
+            get_handler(EntityTypeHandler, {'name': 'foo', 'tags': [], 'series': [], 'meta': ['m']}).post()
+            get_handler(EntityTypeHandler, {'name': 'foo', 'tags': [], 'series': [], 'meta': ['m2']}).post()
+        # create node
+        with patch('api.tree.Session', new=Session):
+            get_handler(EntityHandler, {'parent_id': None, 'entity_type_id': 1, 'meta_1': 'meta_val'}).post()
+
+    def test_delete_removes_object_and_dependants(self):
+        result = get_handler(MetaAttributeHandler).delete(1, 1)
+        self.assertEqual({'success': True}, result)
+        self.assertEqual(len(get_all(Session(), EntityType)), 2)
+        self.assertEqual(len(get_all(Session(), MetaAttribute)), 1)
+        self.assertEqual(len(get_all(Session(), EntityMeta)), 0)
+
+    def test_invalid_request_raises(self):
+        with self.assertRaises(HTTP_404):
+            get_handler(MetaAttributeHandler).delete(10, 1)  # non existing entity type
+        with self.assertRaises(HTTP_404):
+            get_handler(MetaAttributeHandler).delete(1, 10)  # non existing meta attribute
+        with self.assertRaises(HTTP_404):
+            get_handler(MetaAttributeHandler).delete(1, 2)  # meta attribute of different entity type
+
+
+@patch('api.tag_attribute.Session', new=Session)
+class TestTagAttributeDeleteHandler(AbstractTestWithDatabase):
+    def setUp(self):
+        super().setUp()
+        # create entity type
+        with patch('api.entity_type.Session', new=Session):
+            get_handler(EntityTypeHandler, {'name': 'foo', 'tags': ['t'], 'series': [], 'meta': []}).post()
+            get_handler(EntityTypeHandler, {'name': 'foo', 'tags': ['t2'], 'series': [], 'meta': []}).post()
+        # create node
+        with patch('api.tree.Session', new=Session):
+            get_handler(EntityHandler, {'parent_id': None, 'entity_type_id': 1, 'tag_1': 'tag_val'}).post()
+
+    def test_delete_removes_object_and_dependants(self):
+        result = get_handler(TagAttributeHandler).delete(1, 1)
+        self.assertEqual({'success': True}, result)
+        self.assertEqual(len(get_all(Session(), EntityType)), 2)
+        self.assertEqual(len(get_all(Session(), TagAttribute)), 1)
+        self.assertEqual(len(get_all(Session(), EntityTag)), 0)
+
+    def test_invalid_request_raises(self):
+        with self.assertRaises(HTTP_404):
+            get_handler(TagAttributeHandler).delete(10, 1)  # non existing entity type
+        with self.assertRaises(HTTP_404):
+            get_handler(TagAttributeHandler).delete(1, 10)  # non existing tag attribute
+        with self.assertRaises(HTTP_404):
+            get_handler(TagAttributeHandler).delete(1, 2)  # tag attribute of different entity type
+
+
+@patch('api.series_attribute.Session', new=Session)
+class TestSeriesAttributeDeleteHandler(AbstractTestWithDatabase):
+    def setUp(self):
+        super().setUp()
+        # create entity type
+        with patch('api.entity_type.Session', new=Session):
+            get_handler(EntityTypeHandler, {'name': 'foo', 'tags': [], 'series': ['s'], 'meta': []}).post()
+            get_handler(EntityTypeHandler, {'name': 'foo', 'tags': [], 'series': ['s2'], 'meta': []}).post()
+
+    def test_delete_removes_object_and_dependants(self):
+        result = get_handler(SeriesAttributeHandler).delete(1, 1)
+        self.assertEqual({'success': True}, result)
+        self.assertEqual(len(get_all(Session(), EntityType)), 2)
+        self.assertEqual(len(get_all(Session(), SeriesAttribute)), 1)
+
+    def test_invalid_request_raises(self):
+        with self.assertRaises(HTTP_404):
+            get_handler(SeriesAttributeHandler).delete(10, 1)  # non existing entity type
+        with self.assertRaises(HTTP_404):
+            get_handler(SeriesAttributeHandler).delete(1, 10)  # non existing series attribute
+        with self.assertRaises(HTTP_404):
+            get_handler(SeriesAttributeHandler).delete(1, 2)  # series attribute of different entity type
+
+
+@patch('api.tree.Session', new=Session)
+class TestEntityDeleteHandler(AbstractTestWithDatabase):
+    def setUp(self):
+        super().setUp()
+        # create entity type
+        with patch('api.entity_type.Session', new=Session):
+            get_handler(EntityTypeHandler, {'name': 'foo', 'tags': ['t'], 'series': [], 'meta': ['m']}).post()
+        # create nodes
+        with patch('api.tree.Session', new=Session):
+            get_handler(EntityHandler, {'parent_id': None, 'entity_type_id': 1, 'tag_1': 'tag_val',
+                                        'meta_1': 'meta_val'}).post()
+            get_handler(EntityHandler, {'parent_id': 1, 'entity_type_id': 1, 'tag_1': 'tag_val',
+                                        'meta_1': 'meta_val'}).post()
+            get_handler(EntityHandler, {'parent_id': None, 'entity_type_id': 1, 'tag_1': 'tag_val',
+                                        'meta_1': 'meta_val'}).post()
+
+    def test_delete_leaf_removes_object_and_dependants(self):
+        result = get_handler(EntityHandler).delete(3)
+        self.assertEqual({'success': True}, result)
+        self.assertEqual(len(get_all(Session(), Entity)), 2)
+        self.assertEqual(len(get_all(Session(), EntityTag)), 2)
+        self.assertEqual(len(get_all(Session(), EntityMeta)), 2)
+
+    def test_delete_non_leaf_changes_parent_id_of_children(self):
+        result = get_handler(EntityHandler).delete(1)
+        self.assertEqual({'success': True}, result)
+        self.assertEqual(get_one(Session(), Entity, id=2).parent_id_fk, None)
+
+    def test_invalid_request_raises(self):
+        with self.assertRaises(HTTP_404):
+            get_handler(EntityHandler).delete(10)  # non existing entity

--- a/backend/tests/test_api_object_getters.py
+++ b/backend/tests/test_api_object_getters.py
@@ -1,0 +1,91 @@
+import unittest
+from unittest.mock import patch
+
+from api.entity_type import EntityTypeHandler
+from api.meta_attribute import MetaAttributeHandler
+from api.series_attribute import SeriesAttributeHandler
+from api.tag_attribute import TagAttributeHandler
+from api.tree import EntityHandler, TreeHandler
+from .test_utils import mocked_get_all, mocked_get_one, MockedEntityType, MockedEntity, get_handler
+
+
+class TestApiObjectGetters(unittest.TestCase):
+
+    @patch('api.entity_type.get_all', new=mocked_get_all)
+    def test_entity_type_get_without_id_returns_all_entity_types(self):
+        result = get_handler(EntityTypeHandler).get()
+        self.assertEqual(result, [MockedEntityType().to_dict()])
+
+    @patch('api.entity_type.get_one', new=mocked_get_one)
+    def test_entity_type_get_with_id_returns_one_entity_type(self):
+        result = get_handler(EntityTypeHandler).get(1)
+        self.assertEqual(result, MockedEntityType().to_dict())
+
+    @patch('api.meta_attribute.get_all', new=mocked_get_all)
+    @patch('api.meta_attribute.get_one', new=mocked_get_one)
+    def test_meta_attribute_get_without_id_returns_all_meta_attributes(self):
+        result = get_handler(MetaAttributeHandler).get(1)
+        self.assertEqual(result, [meta.to_dict() for meta in MockedEntityType().meta])
+
+    @patch('api.meta_attribute.get_one', new=mocked_get_one)
+    def test_meta_attribute_get_with_id_returns_one_meta_attribute(self):
+        result = get_handler(MetaAttributeHandler).get(1, 1)
+        self.assertEqual(result, MockedEntityType().meta[0].to_dict())
+
+    @patch('api.series_attribute.get_all', new=mocked_get_all)
+    @patch('api.series_attribute.get_one', new=mocked_get_one)
+    def test_series_attribute_get_without_id_returns_all_series_attributes(self):
+        result = get_handler(SeriesAttributeHandler).get(1)
+        self.assertEqual(result, [series.to_dict() for series in MockedEntityType().series])
+
+    @patch('api.series_attribute.get_one', new=mocked_get_one)
+    def test_series_attribute_get_with_id_returns_one_series_attribute(self):
+        result = get_handler(SeriesAttributeHandler).get(1, 1)
+        self.assertEqual(result, MockedEntityType().series[0].to_dict())
+
+    @patch('api.tag_attribute.get_all', new=mocked_get_all)
+    @patch('api.tag_attribute.get_one', new=mocked_get_one)
+    def test_tag_attribute_get_without_id_returns_all_tag_attributes(self):
+        result = get_handler(TagAttributeHandler).get(1)
+        self.assertEqual(result, [tag.to_dict() for tag in MockedEntityType().tags])
+
+    @patch('api.tag_attribute.get_one', new=mocked_get_one)
+    def test_tag_attribute_get_with_id_returns_one_tag_attribute(self):
+        result = get_handler(TagAttributeHandler).get(1, 1)
+        self.assertEqual(result, MockedEntityType().tags[0].to_dict())
+
+    @patch('api.tree.get_one', new=mocked_get_one)
+    def test_entity_get_returns_one_entity(self):
+        result = get_handler(EntityHandler).get(1)
+        self.assertEqual(result, MockedEntity().to_dict())
+
+    @patch('api.tree.get_all', new=mocked_get_all)
+    def test_tree_get_without_id_returns_all_trees(self):
+        result = get_handler(TreeHandler).get()
+
+        self.assertEqual(result, {
+            'tree_metadata': {1: {'children': [],
+                                  'measurements': [sa.id for sa in MockedEntityType().series],
+                                  'name': None,
+                                  'node_id': 1,
+                                  'parent': None,
+                                  'position': {'x': None, 'y': None}}},
+            'tree': [MockedEntity().tree_structure_dict()],
+            'measurements_metadata': {sa.id: sa.to_tree_dict() for sa in MockedEntityType().series},
+        })
+
+    @patch('api.tree.get_one', new=mocked_get_one)
+    @patch('api.tree.get_all', new=mocked_get_all)
+    def test_tree_get_with_id_returns_one_tree(self):
+        result = get_handler(TreeHandler).get(1)
+
+        self.assertEqual(result, {
+            'tree_metadata': {1: {'children': [],
+                                  'measurements': [sa.id for sa in MockedEntityType().series],
+                                  'name': None,
+                                  'node_id': 1,
+                                  'parent': None,
+                                  'position': {'x': None, 'y': None}}},
+            'tree': MockedEntity().tree_structure_dict(),
+            'measurements_metadata': {sa.id: sa.to_tree_dict() for sa in MockedEntityType().series},
+        })

--- a/backend/tests/test_api_object_posts.py
+++ b/backend/tests/test_api_object_posts.py
@@ -1,0 +1,217 @@
+from unittest.mock import patch
+from pycnic.errors import HTTP_400, HTTP_404
+
+from api.entity_type import EntityTypeHandler
+from api.meta_attribute import MetaAttributeHandler
+from api.series_attribute import SeriesAttributeHandler
+from api.tag_attribute import TagAttributeHandler
+from api.tree import EntityHandler
+from database.helpers import get_all
+from database.model import EntityType, TagAttribute, MetaAttribute, SeriesAttribute, Entity
+from .test_utils import Session, AbstractTestWithDatabase, get_handler
+
+
+@patch('api.entity_type.Session', new=Session)
+class TestEntityTypePostHandler(AbstractTestWithDatabase):
+
+    def test_post_creates_object(self):
+        result = get_handler(EntityTypeHandler, {'name': 'foo', 'tags': [], 'series': [], 'meta': []}).post()
+
+        self.assertEqual({'success': True, 'ID': 1}, result)
+        self.assertEqual(len(get_all(Session(), EntityType)), 1)
+        self.assertEqual(len(get_all(Session(), TagAttribute)), 0)
+        self.assertEqual(len(get_all(Session(), MetaAttribute)), 0)
+        self.assertEqual(len(get_all(Session(), SeriesAttribute)), 0)
+
+    def test_post_with_attributes_creates_objects(self):
+        result = get_handler(EntityTypeHandler, {'name': 'foo', 'tags': ['tag1'], 'series': ['series1'],
+                                                 'meta': ['meta1']}).post()
+
+        self.assertEqual({'success': True, 'ID': 1}, result)
+        self.assertEqual(len(get_all(Session(), EntityType)), 1)
+        self.assertEqual(len(get_all(Session(), TagAttribute)), 1)
+        self.assertEqual(len(get_all(Session(), MetaAttribute)), 1)
+        self.assertEqual(len(get_all(Session(), SeriesAttribute)), 1)
+
+    def test_invalid_request_raises(self):
+        handler = get_handler(EntityTypeHandler)
+
+        with self.assertRaises(HTTP_400):
+            handler.request._data = {'name': 'foo', 'tags': [], 'series': []}  # no meta
+            handler.post()
+        with self.assertRaises(HTTP_400):
+            handler.request._data = {'name': 'foo', 'tags': [], 'meta': []}  # no series
+            handler.post()
+        with self.assertRaises(HTTP_400):
+            handler.request._data = {'name': 'foo', 'series': [], 'meta': []}  # no tags
+            handler.post()
+        with self.assertRaises(HTTP_400):
+            handler.request._data = {'tags': [], 'series': [], 'meta': []}  # no name
+            handler.post()
+        self.assertEqual(len(get_all(Session(), EntityType)), 0)
+
+
+@patch('api.meta_attribute.Session', new=Session)
+@patch('api.validators.Session', new=Session)
+class TestMetaAttributePostHandler(AbstractTestWithDatabase):
+    def setUp(self):
+        super().setUp()
+        # create entity type
+        with patch('api.entity_type.Session', new=Session):
+            get_handler(EntityTypeHandler, {'name': 'foo', 'tags': [], 'series': [], 'meta': ['meta_name']}).post()
+
+    def test_post_creates_object(self):
+        self.assertEqual(len(get_all(Session(), MetaAttribute)), 1)
+        result = get_handler(MetaAttributeHandler, {'name': 'foo'}).post(1)
+
+        self.assertEqual({'success': True, 'ID': 2}, result)
+        self.assertEqual(len(get_all(Session(), MetaAttribute)), 2)
+
+    def test_invalid_request_raises(self):
+        self.assertEqual(len(get_all(Session(), MetaAttribute)), 1)
+        handler = get_handler(MetaAttributeHandler)
+
+        with self.assertRaises(HTTP_400):
+            handler.request._data = {}  # no name
+            handler.post(1)
+        with self.assertRaises(HTTP_400):
+            handler.request._data = {'name': 'meta_name'}  # existing name
+            handler.post(1)
+        with self.assertRaises(HTTP_404):
+            handler.request._data = {'name': 'foo'}
+            handler.post(2)  # non-existing entity type
+
+        self.assertEqual(len(get_all(Session(), MetaAttribute)), 1)
+
+
+@patch('api.tag_attribute.Session', new=Session)
+@patch('api.validators.Session', new=Session)
+class TestTagAttributePostHandler(AbstractTestWithDatabase):
+    def setUp(self):
+        super().setUp()
+        # create entity type
+        with patch('api.entity_type.Session', new=Session):
+            get_handler(EntityTypeHandler, {'name': 'foo', 'tags': ['tag_name'], 'series': [], 'meta': []}).post()
+
+    def test_post_creates_object(self):
+        self.assertEqual(len(get_all(Session(), TagAttribute)), 1)
+        result = get_handler(TagAttributeHandler, {'name': 'foo'}).post(1)
+
+        self.assertEqual({'success': True, 'ID': 2}, result)
+        self.assertEqual(len(get_all(Session(), TagAttribute)), 2)
+
+    def test_invalid_request_raises(self):
+        self.assertEqual(len(get_all(Session(), TagAttribute)), 1)
+        handler = get_handler(TagAttributeHandler)
+
+        with self.assertRaises(HTTP_400):
+            handler.request._data = {}  # no name
+            handler.post(1)
+        with self.assertRaises(HTTP_400):
+            handler.request._data = {'name': 'tag_name'}  # existing name
+            handler.post(1)
+        with self.assertRaises(HTTP_404):
+            handler.request._data = {'name': 'foo'}
+            handler.post(2)  # non-existing entity type
+
+        self.assertEqual(len(get_all(Session(), TagAttribute)), 1)
+
+
+@patch('api.series_attribute.Session', new=Session)
+@patch('api.validators.Session', new=Session)
+class TestSeriesAttributePostHandler(AbstractTestWithDatabase):
+    def setUp(self):
+        super().setUp()
+        # create entity type
+        with patch('api.entity_type.Session', new=Session):
+            get_handler(EntityTypeHandler, {'name': 'foo', 'tags': [], 'series': ['series_name'], 'meta': []}).post()
+
+    def test_post_creates_object(self):
+        self.assertEqual(len(get_all(Session(), SeriesAttribute)), 1)
+        result = get_handler(SeriesAttributeHandler, {'name': 'foo'}).post(1)
+
+        self.assertEqual({'success': True, 'ID': 2}, result)
+        self.assertEqual(len(get_all(Session(), SeriesAttribute)), 2)
+
+        # post with more params
+        result = get_handler(SeriesAttributeHandler, {'name': 'foo_prim', 'type': 'enum', 'refresh_time': 3600}).post(1)
+
+        self.assertEqual({'success': True, 'ID': 3}, result)
+        self.assertEqual(len(get_all(Session(), SeriesAttribute)), 3)
+
+    def test_invalid_request_raises(self):
+        self.assertEqual(len(get_all(Session(), SeriesAttribute)), 1)
+        handler = get_handler(SeriesAttributeHandler)
+
+        with self.assertRaises(HTTP_400):
+            handler.request._data = {}  # no name
+            handler.post(1)
+        with self.assertRaises(HTTP_400):
+            handler.request._data = {'name': 'foo', 'type': 'nop'}  # bad type
+            handler.post(1)
+        with self.assertRaises(HTTP_400):
+            handler.request._data = {'name': 'foo', 'refresh_time': '2'}  # bad refresh time
+            handler.post(1)
+        with self.assertRaises(HTTP_400):
+            handler.request._data = {'name': 'series_name'}  # existing name
+            handler.post(1)
+        with self.assertRaises(HTTP_404):
+            handler.request._data = {'name': 'foo'}
+            handler.post(2)  # non-existing entity type
+
+        self.assertEqual(len(get_all(Session(), SeriesAttribute)), 1)
+
+
+@patch('api.tree.Session', new=Session)
+class TestEntityPostHandler(AbstractTestWithDatabase):
+    def setUp(self):
+        super().setUp()
+        # create entity type
+        with patch('api.entity_type.Session', new=Session):
+            get_handler(EntityTypeHandler, {'name': 'foo', 'tags': ['t'], 'series': ['s'], 'meta': ['m']}).post()
+
+    def test_post_creates_object(self):
+        result = get_handler(EntityHandler, {'parent_id': None, 'entity_type_id': 1, 'tag_1': 'tag_val',
+                                             'meta_1': 'meta_val'}).post()
+
+        self.assertEqual({'success': True, 'ID': 1}, result)
+        self.assertEqual(len(get_all(Session(), Entity)), 1)
+
+        result = get_handler(EntityHandler, {'parent_id': 1, 'entity_type_id': 1, 'tag_1': 'tag_val_1',
+                                             'meta_1': 'meta_val'}).post()
+
+        self.assertEqual({'success': True, 'ID': 2}, result)
+        self.assertEqual(len(get_all(Session(), Entity)), 2)
+
+    def test_invalid_request_raises(self):
+        handler = get_handler(EntityHandler)
+
+        with self.assertRaises(HTTP_400):
+            handler.request._data = {'parent_id': None, 'entity_type_id': 1, 'tag_1': 'tag_val'}  # no meta_1
+            handler.post()
+        with self.assertRaises(HTTP_400):
+            handler.request._data = {'parent_id': None, 'entity_type_id': 1, 'meta_1': 'meta_val'}  # no tag_1
+            handler.post()
+        with self.assertRaises(HTTP_400):
+            handler.request._data = {'parent_id': None, 'entity_type_id': 1, 'tag_1': 't', 'meta_1': 'm',
+                                     'tag_10': 'f'}  # unexpected tag_10
+            handler.post()
+        with self.assertRaises(HTTP_400):
+            handler.request._data = {'parent_id': None, 'entity_type_id': 1, 'tag_1': 't', 'meta_1': 'm',
+                                     'meta_10': 'f'}  # unexpected meta_10
+            handler.post()
+        with self.assertRaises(HTTP_400):
+            handler.request._data = {'parent_id': None, 'tag_1': 't', 'meta_1': 'm'}  # no entity type
+            handler.post()
+        with self.assertRaises(HTTP_400):
+            handler.request._data = {'entity_type_id': 1, 'tag_1': 't', 'meta_1': 'm'}  # no parent_id
+            handler.post()
+        with self.assertRaises(HTTP_404):
+            handler.request._data = {'parent_id': 10, 'entity_type_id': 1,
+                                     'tag_1': 't', 'meta_1': 'm'}  # non-existent parent id
+            handler.post()
+        with self.assertRaises(HTTP_404):
+            handler.request._data = {'parent_id': None, 'entity_type_id': 10}  # non-existent entity id
+            handler.post()
+
+        self.assertEqual(len(get_all(Session(), Entity)), 0)

--- a/backend/tests/test_api_object_updaters.py
+++ b/backend/tests/test_api_object_updaters.py
@@ -1,0 +1,104 @@
+from unittest.mock import patch
+
+from pycnic.errors import HTTP_404, HTTP_400
+
+from api.entity_type import EntityTypeHandler
+from api.meta_attribute import MetaAttributeHandler
+from api.tree import EntityHandler
+from database.helpers import get_all, get_one
+from database.model import EntityType, TagAttribute, SeriesAttribute, MetaAttribute, EntityTag, EntityMeta
+from .test_utils import AbstractTestWithDatabase, Session, get_handler
+
+
+@patch('api.entity_type.Session', new=Session)
+class TestEntityTypePutHandler(AbstractTestWithDatabase):
+    def setUp(self):
+        super().setUp()
+        with patch('api.entity_type.Session', new=Session):
+            get_handler(EntityTypeHandler, {'name': 'foo', 'tags': ['t1'], 'series': ['s1'], 'meta': ['m1']}).post()
+
+    def test_put_updates_name(self):
+        result = get_handler(EntityTypeHandler, {'name': 'bar'}).put(1)
+
+        self.assertEqual({'success': True, 'ID': 1}, result)
+        self.assertEqual(len(get_all(Session(), EntityType)), 1)
+        self.assertEqual(get_one(Session(), EntityType, id=1).name, 'bar')
+
+    def test_put_creates_new_objects(self):
+        result = get_handler(EntityTypeHandler, {'tags': ['t2']}).put(1)
+        self.assertEqual({'success': True, 'ID': 1}, result)
+        self.assertEqual(len(get_all(Session(), TagAttribute)), 2)
+
+        result = get_handler(EntityTypeHandler, {'series': ['s2']}).put(1)
+        self.assertEqual({'success': True, 'ID': 1}, result)
+        self.assertEqual(len(get_all(Session(), SeriesAttribute)), 2)
+
+        result = get_handler(EntityTypeHandler, {'meta': ['m2']}).put(1)
+        self.assertEqual({'success': True, 'ID': 1}, result)
+        self.assertEqual(len(get_all(Session(), MetaAttribute)), 2)
+
+    def test_invalid_request_raises(self):
+        with self.assertRaises(HTTP_404):
+            get_handler(EntityTypeHandler, {'name': 'bar'}).put(2)  # invalid entity type id
+        with self.assertRaises(HTTP_400):
+            get_handler(EntityTypeHandler, {'tags': ['t1', 't2']}).put(1)  # existing tag
+        with self.assertRaises(HTTP_400):
+            get_handler(EntityTypeHandler, {'series': ['s1', 's2']}).put(1)  # existing series
+        with self.assertRaises(HTTP_400):
+            get_handler(EntityTypeHandler, {'meta': ['m1', 'm2']}).put(1)  # existing meta
+
+
+@patch('api.meta_attribute.Session', new=Session)
+@patch('api.validators.Session', new=Session)
+class MetaAttributePutHandler(AbstractTestWithDatabase):
+    def setUp(self):
+        super().setUp()
+        with patch('api.entity_type.Session', new=Session):
+            get_handler(EntityTypeHandler, {'name': 'foo', 'tags': [], 'series': [], 'meta': ['m1', 'm2', 'm3']}).post()
+            get_handler(EntityTypeHandler, {'name': 'foo', 'tags': [], 'series': [], 'meta': ['m4']}).post()
+
+    def test_put_updates_name(self):
+        result = get_handler(MetaAttributeHandler, {'name': 'meta_foo'}).put(1, 1)
+
+        self.assertEqual({'success': True, 'ID': 1}, result)
+        self.assertEqual(len(get_all(Session(), MetaAttribute)), 4)
+        self.assertEqual(get_one(Session(), MetaAttribute, id=1).name, 'meta_foo')
+
+    def test_invalid_request_raises(self):
+        with self.assertRaises(HTTP_404):
+            get_handler(MetaAttributeHandler, {'name': 'meta_foo'}).put(10, 1)  # non existing entity type
+        with self.assertRaises(HTTP_404):
+            get_handler(MetaAttributeHandler, {'name': 'meta_foo'}).put(1, 10)  # non existing meta attribute
+        with self.assertRaises(HTTP_404):
+            get_handler(MetaAttributeHandler, {'name': 'meta_foo'}).put(2, 2)  # meta attribute of different entity type
+        with self.assertRaises(HTTP_400):
+            get_handler(MetaAttributeHandler, {'name': 'm2'}).put(1, 1)  # existing name
+
+
+@patch('api.tree.Session', new=Session)
+class TestEntityPutHandler(AbstractTestWithDatabase):
+    def setUp(self):
+        super().setUp()
+        with patch('api.entity_type.Session', new=Session):
+            get_handler(EntityTypeHandler, {'name': 'foo', 'tags': ['t1'], 'series': ['s1'], 'meta': ['m1']}).post()
+            get_handler(EntityTypeHandler, {'name': 'bar', 'tags': ['t2'], 'series': ['s2'], 'meta': ['m2']}).post()
+        with patch('api.tree.Session', new=Session):
+            get_handler(EntityHandler, {'parent_id': None, 'entity_type_id': 1, 'tag_1': 'tag_val',
+                                        'meta_1': 'meta_val'}).post()
+
+    def test_put_updates_fields(self):
+        result = get_handler(EntityHandler, {'tag_1': 'tag_foo', 'meta_1': 'meta_foo'}).put(1)
+
+        self.assertEqual({'success': True, 'ID': 1}, result)
+        self.assertEqual(len(get_all(Session(), EntityTag)), 1)
+        self.assertEqual(len(get_all(Session(), EntityMeta)), 1)
+        self.assertEqual(get_one(Session(), EntityTag, entity_id_fk=1).value, 'tag_foo')
+        self.assertEqual(get_one(Session(), EntityMeta, entity_id_fk=1).value, 'meta_foo')
+
+    def test_invalid_request_raises(self):
+        with self.assertRaises(HTTP_404):
+            get_handler(EntityHandler, {'tag_1': 'tag_foo', 'meta_1': 'meta_foo'}).put(2)  # non existing entity
+        with self.assertRaises(HTTP_404):
+            get_handler(EntityHandler, {'tag_2': 'tag_foo'}).put(1)  # tag not in entity type of entity #1
+        with self.assertRaises(HTTP_404):
+            get_handler(EntityHandler, {'meta_2': 'tag_foo'}).put(1)  # meta not in entity type of entity #1

--- a/backend/tests/test_arithmetic_type_evaluation.py
+++ b/backend/tests/test_arithmetic_type_evaluation.py
@@ -1,18 +1,20 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
+from .test_utils import mocked_get_one
 from websocket.arithmetic import create_measurement_handler, MeasurementIdType, UnaryMeasurementType, BinaryMeasurementType
 
 DEFAULT_ENTITY_ID = 1
 DEFAULT_AGGREGATION_LENGTH = 60
 DEFAULT_AGGREGATION_TYPE = 'mean'
 
-@patch('websocket.arithmetic.InfluxReader.query', return_value=[{'time': 100000, 'value': 0.5}, 
+
+@patch('websocket.arithmetic.InfluxReader.query', return_value=[{'time': 100000, 'value': 0.5},
                                                                 {'time': 100001, 'value': None}])
-@patch('websocket.arithmetic.get_one', return_value=MagicMock())
+@patch('websocket.arithmetic.get_one', new=mocked_get_one)
 class TestArithmeticTypeEvaluation(unittest.TestCase):
 
-    def test_create_measurement_handler_returns_proper_handler_types(self, get_one_patch, query_patch):
+    def test_create_measurement_handler_returns_proper_handler_types(self, query_patch):
         handler = create_measurement_handler(DEFAULT_ENTITY_ID, DEFAULT_AGGREGATION_LENGTH, DEFAULT_AGGREGATION_TYPE,
                                              {'measurement_id': 17})
         self.assertTrue(isinstance(handler, MeasurementIdType))
@@ -30,48 +32,48 @@ class TestArithmeticTypeEvaluation(unittest.TestCase):
         self.assertTrue(isinstance(handler._child2, UnaryMeasurementType))
         self.assertEqual(handler._operator(3, 5), 8)
 
-    def test_measurement_id_returns_proper_data(self, get_one_patch, query_patch):
+    def test_measurement_id_returns_proper_data(self, query_patch):
         handler = create_measurement_handler(DEFAULT_ENTITY_ID, DEFAULT_AGGREGATION_LENGTH, DEFAULT_AGGREGATION_TYPE,
                                              {'measurement_id': 17})
         
         self.assertEqual(handler.evaluate(1, 10), [(100000, 0.5), (100001, None)])
-        # TODO assert that query_patch was called once
+        self.assertEqual(query_patch.call_count, 1)
 
-    def test_unary_measurement_type_returns_proper_data(self, get_one_patch, query_patch):
+    def test_unary_measurement_type_returns_proper_data(self, query_patch):
         handler = create_measurement_handler(DEFAULT_ENTITY_ID, DEFAULT_AGGREGATION_LENGTH, DEFAULT_AGGREGATION_TYPE,
                                              {'unary_operator': 'minus', 'arg': {'measurement_id': 17}})
 
         self.assertEqual(handler.evaluate(1, 10), [(100000, -0.5), (100001, None)])
-        # TODO as in 37
+        self.assertEqual(query_patch.call_count, 1)
 
-    def test_binary_measurement_type_add_returns_proper_data(self, get_one_patch, query_patch):
+    def test_binary_measurement_type_add_returns_proper_data(self, query_patch):
         handler = create_measurement_handler(DEFAULT_ENTITY_ID, DEFAULT_AGGREGATION_LENGTH, DEFAULT_AGGREGATION_TYPE,
                                              {'binary_operator': 'add', 'arg1': {'measurement_id': 17}, 
                                               'arg2': {'measurement_id': 12}})
 
         self.assertEqual(handler.evaluate(1, 10), [(100000, 1), (100001, None)])
-        # TODO 37
+        self.assertEqual(query_patch.call_count, 2)
 
-    def test_binary_measurement_type_minus_returns_proper_data(self, get_one_patch, query_patch):
+    def test_binary_measurement_type_minus_returns_proper_data(self, query_patch):
         handler = create_measurement_handler(DEFAULT_ENTITY_ID, DEFAULT_AGGREGATION_LENGTH, DEFAULT_AGGREGATION_TYPE,
                                              {'binary_operator': 'minus', 'arg1': {'measurement_id': 17}, 
                                               'arg2': {'measurement_id': 12}})
 
         self.assertEqual(handler.evaluate(1, 10), [(100000, 0), (100001, None)])
-        # TODO 37
+        self.assertEqual(query_patch.call_count, 2)
 
-    def test_binary_measurement_type_multiply_returns_proper_data(self, get_one_patch, query_patch):
+    def test_binary_measurement_type_multiply_returns_proper_data(self, query_patch):
         handler = create_measurement_handler(DEFAULT_ENTITY_ID, DEFAULT_AGGREGATION_LENGTH, DEFAULT_AGGREGATION_TYPE,
                                              {'binary_operator': 'multiply', 'arg1': {'measurement_id': 17}, 
                                               'arg2': {'measurement_id': 12}})
 
         self.assertEqual(handler.evaluate(1, 10), [(100000, 0.25), (100001, None)])
-        # TODO 37
+        self.assertEqual(query_patch.call_count, 2)
 
-    def test_binary_measurement_type_divide_returns_proper_data(self, get_one_patch, query_patch):
+    def test_binary_measurement_type_divide_returns_proper_data(self, query_patch):
         handler = create_measurement_handler(DEFAULT_ENTITY_ID, DEFAULT_AGGREGATION_LENGTH, DEFAULT_AGGREGATION_TYPE,
                                              {'binary_operator': 'divide', 'arg1': {'measurement_id': 17}, 
                                               'arg2': {'measurement_id': 12}})
 
         self.assertEqual(handler.evaluate(1, 10), [(100000, 1), (100001, None)])
-        # TODO 37
+        self.assertEqual(query_patch.call_count, 2)

--- a/backend/tests/test_data_downloading.py
+++ b/backend/tests/test_data_downloading.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest.mock import mock_open, patch
+
+from database.telegraf import PointGenerator
+from sensors.parser import FileParser
+from .test_utils import mocked_get_one, MockedEntity
+
+PARSE_FILE_CONTENTS = """2016-01-01 12:00:00.123456,1015.1,1.0
+2016-01-02 18:30:13.543321,44.38,10.0"""
+
+
+@patch('sensors.parser.open', new=mock_open(read_data=PARSE_FILE_CONTENTS))
+@patch('sensors.parser.get_one', new=mocked_get_one)
+class TestDataDownloading(unittest.TestCase):
+
+    def test_file_parsing(self):
+        result = FileParser(1, 'foo').get_values()
+
+        self.assertEqual([{'timestamp': '2016-01-01T12:00:00Z', 'measurements': [('s1', 1015.1), ('s2', 1.0)]},
+                          {'timestamp': '2016-01-02T18:30:13Z', 'measurements': [('s1', 44.38), ('s2', 10.0)]}], result)
+
+    def test_point_generating(self):
+        result = PointGenerator(MockedEntity(), FileParser(1, 'foo')).generate_points()
+
+        self.assertEqual([
+            {'tags': {'id': 1, 'tag_name': 'tag_val'}, 'measurement': 's1',
+             'fields': {'value': 1015.1}, 'time': '2016-01-01T12:00:00Z'},
+            {'tags': {'id': 1, 'tag_name': 'tag_val'}, 'measurement': 's2',
+             'fields': {'value': 1.0}, 'time': '2016-01-01T12:00:00Z'},
+            {'tags': {'id': 1, 'tag_name': 'tag_val'}, 'measurement': 's1',
+             'fields': {'value': 44.38}, 'time': '2016-01-02T18:30:13Z'},
+            {'tags': {'id': 1, 'tag_name': 'tag_val'}, 'measurement': 's2',
+             'fields': {'value': 10.0}, 'time': '2016-01-02T18:30:13Z'},
+        ], result)

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -1,0 +1,121 @@
+# mocked database model
+import unittest
+
+from pycnic.core import Request
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from database.model import TagAttribute, MetaAttribute, SeriesAttribute, EntityType, EntityTag, EntityMeta, Entity, Base
+
+
+engine = create_engine('sqlite://')
+Session = sessionmaker(bind=engine)
+
+
+class AbstractTestWithDatabase(unittest.TestCase):
+    def setUp(self):
+        Base.metadata.create_all(bind=engine)
+
+    def tearDown(self):
+        Base.metadata.drop_all(bind=engine)
+
+
+class MockedTagAttribute(object):
+    def __init__(self, entity_type):
+        self.entity_type = entity_type
+
+    def __getattr__(self, it):
+        return {'id': 1, 'name': 'tag_name', 'entity_type_id_fk': 1, 'delete_ts': None,
+                'entity_type': self.entity_type}.get(it)
+
+    to_dict = TagAttribute.to_dict
+
+
+class MockedMetaAttribute(object):
+    def __init__(self, entity_type):
+        self.entity_type = entity_type
+
+    def __getattr__(self, it):
+        return {'id': 1, 'name': 'tag_name', 'entity_type_id_fk': 1, 'delete_ts': None,
+                'entity_type': self.entity_type}.get(it)
+
+    to_dict = MetaAttribute.to_dict
+
+
+class MockedSeriesAttribute(object):
+    def __init__(self, entity_type, name='series_name', ident=1):
+        self.entity_type = entity_type
+        self.name = name
+        self.id = ident
+
+    def __getattr__(self, it):
+        return {'id': self.id, 'name': self.name, 'entity_type_id_fk': 1, 'delete_ts': None, 'type': 'real',
+                'refresh_time': 1, 'entity_type': self.entity_type}.get(it)
+
+    transform = SeriesAttribute.transform
+    to_dict = SeriesAttribute.to_dict
+    to_tree_dict = SeriesAttribute.to_tree_dict
+
+
+class MockedEntityType(object):
+    def __getattr__(self, it):
+        return {'id': 1, 'name': 'entity_type_name', 'delete_ts': None, 'tags': [MockedTagAttribute(self)],
+                'meta': [MockedMetaAttribute(self)],
+                'series': [MockedSeriesAttribute(self, name='s1'), MockedSeriesAttribute(self, name='s2')]}.get(it)
+
+    to_dict = EntityType.to_dict
+
+
+class MockedEntityTag(object):
+    def __init__(self, entity):
+        self.entity = entity
+
+    def __getattr__(self, it):
+        return {'entity_id_fk': 1, 'tag_id_fk': 1, 'value': 'tag_val', 'delete_ts': None, 'entity': self.entity,
+                'attribute': MockedEntityType().tags[0]}.get(it)
+
+    to_dict = EntityTag.to_dict
+
+
+class MockedEntityMeta(object):
+    def __init__(self, entity):
+        self.entity = entity
+
+    def __getattr__(self, it):
+        return {'entity_id_fk': 1, 'meta_id_fk': 1, 'value': 'meta_val', 'delete_ts': None, 'entity': self.entity,
+                'attribute': MockedEntityType().tags[0]}.get(it)
+
+    to_dict = EntityMeta.to_dict
+
+
+class MockedEntity(object):
+    def __getattr__(self, it):
+        return {'id': 1, 'entity_type_id_fk': 1, 'parent_id_fk': None, 'last_data_fetch_ts': 1000, 'delete_ts': None,
+                'entity_type': MockedEntityType(), 'tags': [MockedEntityTag(self)],
+                'meta': [MockedEntityMeta(self)], 'children': []}.get(it)
+
+    to_dict = Entity.to_dict
+    add_nodes_rec = Entity.add_nodes_rec
+    map_nodes = Entity.map_nodes
+    tree_structure_dict = Entity.tree_structure_dict
+
+
+def mocked_get_one(session, cls, **kwargs):
+    c = cls.__name__
+    return {'EntityType': MockedEntityType(), 'TagAttribute': MockedEntityType().tags[0],
+            'MetaAttribute': MockedEntityType().meta[0], 'SeriesAttribute': MockedEntityType().series[0],
+            'Entity': MockedEntity(), 'EntityTag': MockedEntity().tags[0], 'EntityMeta': MockedEntity().meta[0]}.get(c)
+
+
+def mocked_get_all(session, cls, **kwargs):
+    c = cls.__name__
+    return {'EntityType': [MockedEntityType()], 'TagAttribute': MockedEntityType().tags,
+            'MetaAttribute': MockedEntityType().meta, 'SeriesAttribute': MockedEntityType().series,
+            'Entity': [MockedEntity()], 'EntityTag': MockedEntity().tags, 'EntityMeta': MockedEntity().meta}.get(c)
+
+
+def get_handler(cls, payload=None):
+    handler = cls()
+    handler.request = Request('foo', 'bar', {})
+    handler.request._data = payload or {}
+    return handler

--- a/backend/tests/test_websocket_request_processing.py
+++ b/backend/tests/test_websocket_request_processing.py
@@ -1,6 +1,5 @@
 import unittest
 from unittest.mock import MagicMock
-
 from websocket.request_processor import RequestProcessor
 
 
@@ -42,6 +41,26 @@ class TestWebSocketRequestProcessing(unittest.TestCase):
             self.processor.process_new_request({'request_id': None, 'type': 'cancel_request',
                                                 'params': {'request_id': 17}})
         self.handler1.remove.assert_not_called()
+
+    def test_new_chart_request_creates_handler(self):
+        chart_mock = MagicMock(return_value=10)
+        self.processor.HANDLER_CLASSES['new_chart'] = chart_mock
+        self.processor.process_new_request({'request_id': 1, 'type': 'new_chart', 'params': {'x': 'y'}})
+
+        self.assertEqual(self.processor._requests.get(1), 10)
+        chart_mock.assert_called_once_with(1, {'x': 'y'})
+
+    def test_new_live_data_request_creates_handler(self):
+        data_mock = MagicMock(return_value=10)
+        self.processor.HANDLER_CLASSES['new_live_data'] = data_mock
+        self.processor.process_new_request({'request_id': 1, 'type': 'new_live_data', 'params': {'x': 'y'}})
+
+        self.assertEqual(self.processor._requests.get(1), 10)
+        data_mock.assert_called_once_with(1, {'x': 'y'})
+
+    def test_non_existing_request_type_raises(self):
+        with self.assertRaises(ValueError):
+            self.processor.process_new_request({'request_id': 1, 'type': 'fake_request', 'params': {}})
 
     def test_run_requests(self):
         self.assertEqual([1, 2], self.processor.run_requests())

--- a/backend/websocket/request_processor.py
+++ b/backend/websocket/request_processor.py
@@ -57,6 +57,6 @@ class RequestProcessor(object):
                 handler = self.HANDLER_CLASSES[request_type](request_id, params)
                 self._requests[request_id] = handler
             else:
-                raise ValueError('Request type {} not found'.format(type))
+                raise ValueError('Request type {} not found'.format(request_type))
         finally:
             self._lock.release()


### PR DESCRIPTION
Zestaw testów pokrywający (według raportu nosetests) 89% kodu poza samymi modułami serwerów, 79% wliczając także `api/app.py`, `websocket/server.py` i `sensors/data_downloader.py`. Ponadto testy wyłapały kilka mniejszych lub większych błędów (i wreszcie poprawiłem tego buga z usuwaniem entity type). Odpalanie testów:
`(venv) $ nosetests --with-coverage --cover-package=api,sensors,database,websocket tests/`