### PR TITLE
Implement RequestManager

### DIFF
--- a/frontend/src/containers/RequestManager/__tests__/RequestManager.actions.test.js
+++ b/frontend/src/containers/RequestManager/__tests__/RequestManager.actions.test.js
@@ -1,0 +1,81 @@
+import { Set } from 'immutable'
+import {
+  requestNewLiveData,
+  requestNewChart,
+  cancelRequest,
+} from '../actions'
+import { HANDLE_REQUEST } from '../constants'
+
+describe('RequestManager actions', () => {
+  it('requestNewLiveData is consistent with protocol specification', () => {
+    const newLiveDataRequest = requestNewLiveData(1, 2)
+    const protocolNewLiveDataRequest = {
+      request_id: 1,
+      type: "new_live_data",
+      params: {
+        node_id: 1,
+        measurement_id: 2,
+      },
+    }
+
+    expect(newLiveDataRequest.type).toEqual(HANDLE_REQUEST)
+    expect(newLiveDataRequest.message.type).toEqual(protocolNewLiveDataRequest.type)
+    expect(newLiveDataRequest.message.params).toEqual(protocolNewLiveDataRequest.params)
+    expect(typeof newLiveDataRequest.message.request_id).toBe('number')
+  })
+
+  it('requestNewChart is consistent with protocol specification', () => {
+    const chartParams = {
+      node_id: 1,
+      begin_ts: 1490989996,
+      end_ts: 1490989999,
+      requested_data: {
+        measurement_id: 2,
+      },
+      update_data: false,
+      aggregation_length: 1,
+      aggregation_type: "mean",
+    }
+
+    const newChartRequest = requestNewChart(chartParams)
+    const protocolNewChartRequest = {
+      request_id: 1,
+      type: "new_chart",
+      params: chartParams,
+    }
+
+    expect(newChartRequest.type).toEqual(HANDLE_REQUEST)
+    expect(newChartRequest.message.type).toEqual(protocolNewChartRequest.type)
+    expect(newChartRequest.message.params).toEqual(protocolNewChartRequest.params)
+    expect(typeof newChartRequest.message.request_id).toBe('number')
+  })
+
+  it('cancelRequest is consistent with protocol specification', () => {
+    const cancelRequestAction = cancelRequest(42)
+    const protocolCancelRequest = {
+      request_id: null,
+      type: "cancel_request",
+      params: {
+        request_id: 42,
+      }
+    }
+
+    expect(cancelRequestAction.type).toEqual(HANDLE_REQUEST)
+    expect(cancelRequestAction.message).toEqual(protocolCancelRequest)
+  })
+
+  it('all requests have unique id', () => {
+    const r1 = requestNewLiveData(1, 2)
+    const r2 = requestNewLiveData(1, 2)
+    const r3 = requestNewLiveData(2, 3)
+    const r4 = requestNewChart({})
+    let requestIds = new Set()
+
+    requestIds = requestIds.add(r1.message.request_id)
+    requestIds = requestIds.add(r2.message.request_id)
+    requestIds = requestIds.add(r3.message.request_id)
+    requestIds = requestIds.add(r4.message.request_id)
+
+    expect(requestIds.size).toBe(4)
+  })
+})

--- a/frontend/src/containers/RequestManager/__tests__/RequestManager.reducer.test.js
+++ b/frontend/src/containers/RequestManager/__tests__/RequestManager.reducer.test.js
@@ -8,7 +8,7 @@ import {
 } from '../constants'
 import {
   sendRequest,
-  requestMessage,
+  messageFromServer,
   websocketDisconnected,
   sendRequestFail,
 } from '../../WebsocketConnection/actions'
@@ -62,7 +62,7 @@ describe('RequestManager reducer', () => {
   })
 
   it('drops incoming request messages from requests that we do not subscribe', () => {
-    const action1 = requestMessage(message1)
+    const action1 = messageFromServer(message1)
 
     const state1 = reducer(initialState, action1)
     expect(state1.size).toBe(1)
@@ -91,8 +91,8 @@ describe('RequestManager reducer', () => {
   it('saves incoming data for PENDING_STATE requests', () => {
     const sendMessage1Request = sendRequest(message1Request)
     let state = reducer(initialState, sendMessage1Request)
-    const requestMessage1 = requestMessage(message1)
-    state = reducer(state, requestMessage1)
+    const messageFromServer1 = messageFromServer(message1)
+    state = reducer(state, messageFromServer1)
     expect(state.size).toBe(1)
     expect(state.get('activeRequests').size).toBe(1)
     // message1 data and type field + one RequestManager field for saving "staleness"
@@ -103,8 +103,8 @@ describe('RequestManager reducer', () => {
     const sendMessage2Request = sendRequest(message2Request)
     state = reducer(state, sendMessage2Request)
     expect(state.get('activeRequests').size).toBe(2)
-    const requestMessage2 = requestMessage(message2)
-    state = reducer(state, requestMessage2)
+    const messageFromServer2 = messageFromServer(message2)
+    state = reducer(state, messageFromServer2)
     expect(state.get('activeRequests').size).toBe(2)
     expect(state.get('activeRequests').get(1).size).toBe(3)
     expect(state.get('activeRequests').get(1).get('state')).toBe(FRESH_STATE)
@@ -119,12 +119,12 @@ describe('RequestManager reducer', () => {
   it('updates subscribed requests on new data', () => {
     const sendMessage1Request = sendRequest(message1Request)
     let state = reducer(initialState, sendMessage1Request)
-    const requestMessage1 = requestMessage(message1)
-    state = reducer(state, requestMessage1)
+    const messageFromServer1 = messageFromServer(message1)
+    state = reducer(state, messageFromServer1)
 
     let newMessage1 = message1
     newMessage1 = newMessage1.set('data', newMessage1.get('data').set('value', 3.1415))
-    const requestNewMessage1 = requestMessage(newMessage1)
+    const requestNewMessage1 = messageFromServer(newMessage1)
     state = reducer(state, requestNewMessage1)
     expect(state.size).toBe(1)
     expect(state.get('activeRequests').size).toBe(1)
@@ -149,8 +149,8 @@ describe('RequestManager reducer', () => {
     let state = reducer(initialState, sendMessage1Request)
     expect(state.get('activeRequests').size).toBe(1)
     expect(state.get('activeRequests').get(1).get('state')).toBe(PENDING_STATE)
-    const requestMessage1 = requestMessage(message1)
-    state = reducer(state, requestMessage1)
+    const messageFromServer1 = messageFromServer(message1)
+    state = reducer(state, messageFromServer1)
     expect(state.get('activeRequests').size).toBe(1)
     expect(state.get('activeRequests').get(1).get('state')).toBe(FRESH_STATE)
     state = reducer(state, websocketDisconnected())
@@ -161,8 +161,8 @@ describe('RequestManager reducer', () => {
   it('drops PENDING_STATE requests and makes other requests into STALE_STATE on WebSocket disconnection', () => {
     const sendMessage1Request = sendRequest(message1Request)
     let state = reducer(initialState, sendMessage1Request)
-    const requestMessage1 = requestMessage(message1)
-    state = reducer(state, requestMessage1)
+    const messageFromServer1 = messageFromServer(message1)
+    state = reducer(state, messageFromServer1)
     const sendMessage2Request = sendRequest(message2Request)
     state = reducer(state, sendMessage2Request)
     expect(state.get('activeRequests').size).toBe(2)

--- a/frontend/src/containers/RequestManager/__tests__/RequestManager.reducer.test.js
+++ b/frontend/src/containers/RequestManager/__tests__/RequestManager.reducer.test.js
@@ -1,0 +1,217 @@
+import { fromJS } from 'immutable'
+
+import {
+  HANDLE_REQUESTS,
+  PENDING_STATE,
+  FRESH_STATE,
+  STALE_STATE,
+} from '../constants'
+import {
+  sendRequest,
+  requestMessage,
+  websocketDisconnected,
+  sendRequestFail,
+} from '../../WebsocketConnection/actions'
+import {
+  requestNewLiveData,
+  requestNewChart,
+  cancelRequest,
+} from '../actions'
+import reducer from '../reducer'
+
+describe('RequestManager reducer', () => {
+
+  // Some constants used by more than 1 test
+  const initialState = reducer(undefined, {})
+  const message1Request = {
+    request_id: 1,
+    type: 'new_live_data',
+    params: {
+      node_id: 1,
+      measurement_id: 1,
+    },
+  }
+  const message1 = fromJS({
+    request_id: 1,
+    type: "new_live_data",
+    data: {
+      value: 42.01,
+      timestamp: 1490610672,
+    },
+  })
+  const message2Request = {
+    request_id: 2,
+    type: 'new_live_data',
+    params: {
+      node_id: 2,
+      measurement_id: 2,
+    },
+  }
+  const message2 = fromJS({
+    request_id: 2,
+    type: "new_live_data",
+    data: {
+      value: 43.01,
+      timestamp: 1490610695,
+    },
+  })
+
+  it('returns correct initial state', () => {
+    expect(initialState.size).toBe(1)
+    expect(initialState.get('activeRequests').size).toBe(0)
+  })
+
+  it('drops incoming request messages from requests that we do not subscribe', () => {
+    const action1 = requestMessage(message1)
+
+    const state1 = reducer(initialState, action1)
+    expect(state1.size).toBe(1)
+    // request 1 was not in PENDING state, so we're not expecting any messages
+    expect(state1.get('activeRequests').size).toBe(0)
+
+  })
+
+  it('changes request state to PENDING_STATE on sending message to WebSocket', () => {
+    const sendMessage1Request = sendRequest(message1Request)
+    let state = reducer(initialState, sendMessage1Request)
+    expect(state.size).toBe(1)
+    expect(state.get('activeRequests').size).toBe(1)
+    expect(state.get('activeRequests').get(1).size).toBe(1)
+    expect(state.get('activeRequests').get(1).get('state')).toBe(PENDING_STATE)
+    const sendMessage2Request = sendRequest(message2Request)
+    state = reducer(state, sendMessage2Request)
+    expect(state.size).toBe(1)
+    expect(state.get('activeRequests').size).toBe(2)
+    expect(state.get('activeRequests').get(1).size).toBe(1)
+    expect(state.get('activeRequests').get(1).get('state')).toBe(PENDING_STATE)
+    expect(state.get('activeRequests').get(2).size).toBe(1)
+    expect(state.get('activeRequests').get(2).get('state')).toBe(PENDING_STATE)
+  })
+
+  it('saves incoming data for PENDING_STATE requests', () => {
+    const sendMessage1Request = sendRequest(message1Request)
+    let state = reducer(initialState, sendMessage1Request)
+    const requestMessage1 = requestMessage(message1)
+    state = reducer(state, requestMessage1)
+    expect(state.size).toBe(1)
+    expect(state.get('activeRequests').size).toBe(1)
+    // message1 data and type field + one RequestManager field for saving "staleness"
+    expect(state.get('activeRequests').get(1).size).toBe(3)
+    expect(state.get('activeRequests').get(1).get('state')).toBe(FRESH_STATE)
+    expect(state.get('activeRequests').get(1).get('data')).toEqual(message1.get('data'))
+    expect(state.get('activeRequests').get(1).get('type')).toBe(message1.get('type'))
+    const sendMessage2Request = sendRequest(message2Request)
+    state = reducer(state, sendMessage2Request)
+    expect(state.get('activeRequests').size).toBe(2)
+    const requestMessage2 = requestMessage(message2)
+    state = reducer(state, requestMessage2)
+    expect(state.get('activeRequests').size).toBe(2)
+    expect(state.get('activeRequests').get(1).size).toBe(3)
+    expect(state.get('activeRequests').get(1).get('state')).toBe(FRESH_STATE)
+    expect(state.get('activeRequests').get(1).get('data')).toEqual(message1.get('data'))
+    expect(state.get('activeRequests').get(1).get('type')).toBe(message1.get('type'))
+    expect(state.get('activeRequests').get(2).size).toBe(3)
+    expect(state.get('activeRequests').get(2).get('state')).toBe(FRESH_STATE)
+    expect(state.get('activeRequests').get(2).get('data')).toEqual(message2.get('data'))
+    expect(state.get('activeRequests').get(2).get('type')).toBe(message2.get('type'))
+  })
+
+  it('updates subscribed requests on new data', () => {
+    const sendMessage1Request = sendRequest(message1Request)
+    let state = reducer(initialState, sendMessage1Request)
+    const requestMessage1 = requestMessage(message1)
+    state = reducer(state, requestMessage1)
+
+    let newMessage1 = message1
+    newMessage1 = newMessage1.set('data', newMessage1.get('data').set('value', 3.1415))
+    const requestNewMessage1 = requestMessage(newMessage1)
+    state = reducer(state, requestNewMessage1)
+    expect(state.size).toBe(1)
+    expect(state.get('activeRequests').size).toBe(1)
+    expect(state.get('activeRequests').get(1).size).toBe(3)
+    expect(state.get('activeRequests').get(1).get('state')).toBe(FRESH_STATE)
+    expect(state.get('activeRequests').get(1).get('data')).not.toEqual(message1.get('data'))
+    expect(state.get('activeRequests').get(1).get('data')).toEqual(newMessage1.get('data'))
+    expect(state.get('activeRequests').get(1).get('type')).toBe(newMessage1.get('type'))
+  })
+
+  it('drops PENDING_STATE requests on WebSocket disconnection', () => {
+    const sendMessage1Request = sendRequest(message1Request)
+    let state = reducer(initialState, sendMessage1Request)
+    expect(state.get('activeRequests').get(1).size).toBe(1)
+    expect(state.get('activeRequests').get(1).get('state')).toBe(PENDING_STATE)
+    state = reducer(state, websocketDisconnected())
+    expect(state.get('activeRequests').size).toBe(0)
+  })
+
+  it('makes FRESH_STATE requests into STALE_STATE requests on WebSocket disconnection', () => {
+    const sendMessage1Request = sendRequest(message1Request)
+    let state = reducer(initialState, sendMessage1Request)
+    expect(state.get('activeRequests').size).toBe(1)
+    expect(state.get('activeRequests').get(1).get('state')).toBe(PENDING_STATE)
+    const requestMessage1 = requestMessage(message1)
+    state = reducer(state, requestMessage1)
+    expect(state.get('activeRequests').size).toBe(1)
+    expect(state.get('activeRequests').get(1).get('state')).toBe(FRESH_STATE)
+    state = reducer(state, websocketDisconnected())
+    expect(state.get('activeRequests').size).toBe(1)
+    expect(state.get('activeRequests').get(1).get('state')).toBe(STALE_STATE)
+  })
+
+  it('drops PENDING_STATE requests and makes other requests into STALE_STATE on WebSocket disconnection', () => {
+    const sendMessage1Request = sendRequest(message1Request)
+    let state = reducer(initialState, sendMessage1Request)
+    const requestMessage1 = requestMessage(message1)
+    state = reducer(state, requestMessage1)
+    const sendMessage2Request = sendRequest(message2Request)
+    state = reducer(state, sendMessage2Request)
+    expect(state.get('activeRequests').size).toBe(2)
+    expect(state.get('activeRequests').get(1).get('state')).toBe(FRESH_STATE)
+    expect(state.get('activeRequests').get(2).get('state')).toBe(PENDING_STATE)
+    state = reducer(state, websocketDisconnected())
+    expect(state.get('activeRequests').size).toBe(1)
+    expect(state.get('activeRequests').get(1).get('state')).toBe(STALE_STATE)
+  })
+
+  it('drops requests on after cancelRequest action', () => {
+    const sendMessage1Request = sendRequest(message1Request)
+    const sendMessage2Request = sendRequest(message2Request)
+    let state = reducer(initialState, sendMessage1Request)
+    state = reducer(state, sendMessage2Request)
+    expect(state.get('activeRequests').size).toBe(2)
+    expect(state.get('activeRequests').get(1).get('state')).toBe(PENDING_STATE)
+    expect(state.get('activeRequests').get(2).get('state')).toBe(PENDING_STATE)
+    const cancelRequestAction = cancelRequest(1)
+    state = reducer(state, cancelRequestAction)
+    expect(state.get('activeRequests').size).toBe(1)
+    expect(state.get('activeRequests').get(2).get('state')).toBe(PENDING_STATE)
+  })
+
+  it('drops requests on SEND_REQUEST_FAIL from WebSocket', () => {
+    const sendMessage1Request = sendRequest(message1Request)
+    const sendMessage2Request = sendRequest(message2Request)
+    let state = reducer(initialState, sendMessage1Request)
+    state = reducer(state, sendMessage2Request)
+    expect(state.get('activeRequests').size).toBe(2)
+    expect(state.get('activeRequests').get(1).get('state')).toBe(PENDING_STATE)
+    expect(state.get('activeRequests').get(2).get('state')).toBe(PENDING_STATE)
+    const sendRequest1Fail = sendRequestFail(1)
+    state = reducer(state, sendRequest1Fail)
+    expect(state.get('activeRequests').size).toBe(1)
+    expect(state.get('activeRequests').get(2).get('state')).toBe(PENDING_STATE)
+  })
+
+  // saga handles them
+  it('ignores HANDLE_REQUEST actions of type other than "cancel_request"', () => {
+    const sendMessage1Request = sendRequest(message1Request)
+    const sendMessage2Request = sendRequest(message2Request)
+    let state = reducer(initialState, sendMessage1Request)
+    state = reducer(state, sendMessage2Request)
+    expect(state.get('activeRequests').size).toBe(2)
+    expect(state.get('activeRequests').get(1).get('state')).toBe(PENDING_STATE)
+    expect(state.get('activeRequests').get(2).get('state')).toBe(PENDING_STATE)
+    let newState = reducer(state, requestNewLiveData(1, 1))
+    newState = reducer(newState, requestNewChart({}))
+    expect(state).toEqual(newState)
+  })
+})

--- a/frontend/src/containers/RequestManager/__tests__/RequestManager.sagas.test.js
+++ b/frontend/src/containers/RequestManager/__tests__/RequestManager.sagas.test.js
@@ -1,0 +1,54 @@
+import { call, takeEvery, put } from 'redux-saga/effects'
+
+import {
+  handleRequestSaga,
+  handleRequest,
+} from '../sagas'
+import {
+  requestNewLiveData,
+  requestNewChart,
+  cancelRequest
+} from '../actions'
+import {
+  HANDLE_REQUEST,
+} from '../constants'
+import { sendRequest } from '../../WebsocketConnection/actions'
+
+describe('RequestManager sagas', () => {
+  it('requestNewLiveData is passed to WebsocketConnection', () => {
+    const newLiveDataRequest = requestNewLiveData(1, 2)
+    const generatorParent = handleRequestSaga()
+    const generatorChild = handleRequest(newLiveDataRequest)
+
+    // handleRequest will be called on HANDLE_REQUEST action type
+    expect(generatorParent.next().value).toEqual(call(takeEvery, HANDLE_REQUEST, handleRequest))
+    // so newLiveDataRequest will trigger saga call
+    expect(newLiveDataRequest.type).toBe(HANDLE_REQUEST)
+    // and then we expect saga to dispatch the action to store
+    expect(generatorChild.next().value).toEqual(put(sendRequest(newLiveDataRequest.message)))
+    // after which the saga should finish its execution
+    expect(generatorChild.next().done).toBeTruthy()
+  })
+
+  it('requestNewChart is passed to WebsocketConnection', () => {
+    const newChartRequest = requestNewChart({})
+    const generatorParent = handleRequestSaga()
+    const generatorChild = handleRequest(newChartRequest)
+
+    expect(generatorParent.next().value).toEqual(call(takeEvery, HANDLE_REQUEST, handleRequest))
+    expect(newChartRequest.type).toBe(HANDLE_REQUEST)
+    expect(generatorChild.next().value).toEqual(put(sendRequest(newChartRequest.message)))
+    expect(generatorChild.next().done).toBeTruthy()
+  })
+
+  it('cancelRequest is passed to WebsocketConnection', () => {
+    const cancelRequestAction = cancelRequest(1)
+    const generatorParent = handleRequestSaga()
+    const generatorChild = handleRequest(cancelRequestAction)
+
+    expect(generatorParent.next().value).toEqual(call(takeEvery, HANDLE_REQUEST, handleRequest))
+    expect(cancelRequestAction.type).toBe(HANDLE_REQUEST)
+    expect(generatorChild.next().value).toEqual(put(sendRequest(cancelRequestAction.message)))
+    expect(generatorChild.next().done).toBeTruthy()
+  })
+})

--- a/frontend/src/containers/RequestManager/__tests__/RequestManager.selectors.test.js
+++ b/frontend/src/containers/RequestManager/__tests__/RequestManager.selectors.test.js
@@ -1,0 +1,33 @@
+import { fromJS } from 'immutable'
+import {
+  requestNewLiveData,
+} from '../actions'
+import {
+  sendRequest,
+} from '../../WebsocketConnection/actions'
+import {
+  selectRequestManager,
+  selectActiveRequestWithId,
+} from '../selectors'
+import reducer from '../reducer'
+
+describe('RequestManager selectors', () => {
+  const state = fromJS({
+    RequestManager: reducer(undefined, {})
+  })
+  it('chooses correct fields from global state', () => {
+    let r1 = requestNewLiveData(1, 1)
+    let r2 = requestNewLiveData(1, 2)
+    const sendR1 = sendRequest(r1.message)
+    const sendR2 = sendRequest(r2.message)
+    let newState = state
+    newState = newState.set('RequestManager', reducer(newState.get('RequestManager'), sendR1))
+    newState = newState.set('RequestManager', reducer(newState.get('RequestManager'), sendR2))
+    expect(newState.get('RequestManager').get('activeRequests').size).toBe(2)
+    newState = newState.setIn(['RequestManager', 'activeRequests', 1, 'testFlag'], 1)
+    newState = newState.setIn(['RequestManager', 'activeRequests', 2, 'testFlag'], 2)
+    expect(selectRequestManager(newState)).toEqual(newState.get('RequestManager'))
+    expect(selectActiveRequestWithId(1)(newState).get('testFlag')).toBe(1)
+    expect(selectActiveRequestWithId(2)(newState).get('testFlag')).toBe(2)
+  })
+})

--- a/frontend/src/containers/RequestManager/actions.js
+++ b/frontend/src/containers/RequestManager/actions.js
@@ -1,0 +1,54 @@
+import {
+  HANDLE_REQUEST,
+  CANCEL_REQUEST,
+} from './constants'
+
+function getNextRequestId() {
+  if (typeof getNextRequestId.nextId === 'undefined') {
+    getNextRequestId.nextId = 1
+  }
+  return (getNextRequestId.nextId++)
+}
+
+export function requestNewLiveData(nodeId, measurementId) {
+  let requestId = getNextRequestId()
+  let message = {
+    request_id: requestId,
+    type: 'new_live_data',
+    params: {
+      node_id: nodeId,
+      measurement_id: measurementId,
+    }
+  }
+  return {
+    type: HANDLE_REQUEST,
+    message,
+  }
+}
+
+export function requestNewChart(params) {
+  let requestId = getNextRequestId();
+  let message = {
+    request_id: requestId,
+    type: 'new_chart',
+    params,
+  }
+  return {
+    type: HANDLE_REQUEST,
+    message,
+  }
+}
+
+export function cancelRequest(requestId) {
+  let message = {
+    request_id: null,
+    type: 'cancel_request',
+    params: {
+      request_id: requestId,
+    },
+  }
+  return {
+    type: HANDLE_REQUEST,
+    message,
+  }
+}

--- a/frontend/src/containers/RequestManager/constants.js
+++ b/frontend/src/containers/RequestManager/constants.js
@@ -1,0 +1,5 @@
+export const HANDLE_REQUEST = 'luminis/RequestManager/HANDLE_REQUEST'
+
+export const PENDING_STATE = 'PENDING'
+export const FRESH_STATE = 'FRESH'
+export const STALE_STATE = 'STALE'

--- a/frontend/src/containers/RequestManager/reducer.js
+++ b/frontend/src/containers/RequestManager/reducer.js
@@ -1,0 +1,92 @@
+/*
+ * RequestManager reducer
+ *
+ * RequestManager deals with sending
+ * and receiving data from WebSocket.
+ * It manages all data subscriptions.
+ *
+ */
+
+import { Map, Set } from 'immutable';
+
+import {
+  HANDLE_REQUEST,
+
+  PENDING_STATE,
+  FRESH_STATE,
+  STALE_STATE,
+} from './constants'
+
+import {
+  SEND_REQUEST,
+  SEND_REQUEST_OK,
+  SEND_REQUEST_FAIL,
+  WEBSOCKET_DISCONNECTED,
+  REQUEST_MESSAGE,
+} from '../WebsocketConnection/constants'
+
+/*
+ * activeRequests - map from request_id to current data for that request.
+ *                  Format of the data is as described in communication protocol,
+ *                  with additional field 'state' containing:
+ *                  PENDING_STATE - no data was yet received (no protocol fields present then)
+ *                  FRESH_STATE - data is 'fresh'
+ *                  STALE_STATE - data is 'stale' (e.g. websocket was disconnected)
+ */
+const initialState = new Map({
+  activeRequests: new Map(),
+})
+
+/*
+ * On WebSocket disconnection we want to save
+ * data that may still be used, but somehow flag
+ * that data stale. That's why in requests that have
+ * FRESH_STATE, we change state of the data to STALE_STATE.
+ * We also drop PENDING_STATE requests, as they won't be
+ * realized anyway.
+ */
+function websocketDisconnectCallback(activeRequests) {
+  return activeRequests
+    .filter((requestData) => requestData.get('state') !== PENDING_STATE)
+    .map((requestData) => requestData.set('state', STALE_STATE))
+}
+
+function requestManagerReducer(state = initialState, action) {
+  switch (action.type) {
+    case HANDLE_REQUEST:
+      if (action.message.type === 'cancel_request') {
+        let requestId = action.message.params.request_id
+        return state
+          .set('activeRequests', state.get('activeRequests').delete(requestId))
+      }
+      return state
+    case SEND_REQUEST_FAIL:
+      return state
+        .set('activeRequests', state.get('activeRequests').delete(action.request_id))
+    case SEND_REQUEST:
+      let updatedRequests = state
+        .get('activeRequests')
+        .set(action.request.request_id, new Map({ state: PENDING_STATE }))
+      return state
+        .set('activeRequests', updatedRequests)
+    case WEBSOCKET_DISCONNECTED:
+      return state
+        .set('activeRequests', websocketDisconnectCallback(state.get('activeRequests')))
+    case REQUEST_MESSAGE:
+      let requestMessage = new Map({
+        state: FRESH_STATE,
+        type: action.message.get('type'),
+        data: action.message.get('data'),
+      })
+      // In order to save incoming request data, we must have it subscribed
+      if (state.get('activeRequests').get(action.message.get('request_id'))) {
+        return state
+          .set('activeRequests', state.get('activeRequests').set(action.message.get('request_id'), requestMessage))
+      }
+      return state  
+    default:
+      return state
+  }
+}
+
+export default requestManagerReducer

--- a/frontend/src/containers/RequestManager/reducer.js
+++ b/frontend/src/containers/RequestManager/reducer.js
@@ -22,7 +22,7 @@ import {
   SEND_REQUEST_OK,
   SEND_REQUEST_FAIL,
   WEBSOCKET_DISCONNECTED,
-  REQUEST_MESSAGE,
+  WEBSOCKET_MESSAGE_FROM_SERVER,
 } from '../WebsocketConnection/constants'
 
 /*
@@ -72,8 +72,8 @@ function requestManagerReducer(state = initialState, action) {
     case WEBSOCKET_DISCONNECTED:
       return state
         .set('activeRequests', websocketDisconnectCallback(state.get('activeRequests')))
-    case REQUEST_MESSAGE:
-      let requestMessage = new Map({
+    case WEBSOCKET_MESSAGE_FROM_SERVER:
+      let serverMessage = new Map({
         state: FRESH_STATE,
         type: action.message.get('type'),
         data: action.message.get('data'),
@@ -81,7 +81,7 @@ function requestManagerReducer(state = initialState, action) {
       // In order to save incoming request data, we must have it subscribed
       if (state.get('activeRequests').get(action.message.get('request_id'))) {
         return state
-          .set('activeRequests', state.get('activeRequests').set(action.message.get('request_id'), requestMessage))
+          .set('activeRequests', state.get('activeRequests').set(action.message.get('request_id'), serverMessage))
       }
       return state  
     default:

--- a/frontend/src/containers/RequestManager/sagas.js
+++ b/frontend/src/containers/RequestManager/sagas.js
@@ -1,0 +1,17 @@
+import { call, takeEvery, put } from 'redux-saga/effects'
+
+import { sendRequest } from '../WebsocketConnection/actions'
+import { HANDLE_REQUEST } from './constants'
+
+export function* handleRequest(action) {
+  yield put(sendRequest(action.message))
+}
+
+// Passes request from component to WebsocketConnection
+export function* handleRequestSaga() {
+  yield call(takeEvery, HANDLE_REQUEST, handleRequest)
+}
+
+export default [
+  handleRequestSaga,
+]

--- a/frontend/src/containers/RequestManager/selectors.js
+++ b/frontend/src/containers/RequestManager/selectors.js
@@ -1,0 +1,14 @@
+import { createSelector } from 'reselect';
+import { fromJS } from 'immutable';
+
+export const selectRequestManager = (state) => state.get('RequestManager');
+
+export const selectActiveRequests = createSelector(
+  selectRequestManager,
+  (requestManagerState) => requestManagerState.get('activeRequests')
+)
+
+export const selectActiveRequestWithId = (requestId) => createSelector(
+  selectActiveRequests,
+  (activeRequests) => activeRequests.get(requestId)
+)

--- a/frontend/src/containers/WebsocketConnection/actions.js
+++ b/frontend/src/containers/WebsocketConnection/actions.js
@@ -2,7 +2,12 @@ import {
   CONNECT_WEBSOCKET,
   PROCESS_DATA,
   SAVE_WEBSOCKET,
-  SEND_REQUEST
+  SEND_REQUEST,
+  WEBSOCKET_CONNECTED,
+  WEBSOCKET_DISCONNECTED,
+  SEND_REQUEST_OK,
+  SEND_REQUEST_FAIL,
+  REQUEST_MESSAGE,
 } from './constants';
 
 export function connectWebsocket(url, onOpen, onMessage, onClose) {
@@ -34,4 +39,38 @@ export function sendRequest(request) {
     type: SEND_REQUEST,
     request,
   };
+}
+
+/* Parts of the new API (not yet implemented) */
+export function websocketConnected() {
+  return {
+    type: WEBSOCKET_CONNECTED,
+  }
+}
+
+export function websocketDisconnected() {
+  return {
+    type: WEBSOCKET_DISCONNECTED,
+  }
+}
+
+export function sendRequestSuccess(request_id) {
+  return {
+    type: SEND_REQUEST_OK,
+    request_id,
+  }
+}
+
+export function sendRequestFail(request_id) {
+  return {
+    type: SEND_REQUEST_FAIL,
+    request_id,
+  }
+}
+
+export function requestMessage(message) {
+  return {
+    type: REQUEST_MESSAGE,
+    message,
+  }
 }

--- a/frontend/src/containers/WebsocketConnection/actions.js
+++ b/frontend/src/containers/WebsocketConnection/actions.js
@@ -7,7 +7,7 @@ import {
   WEBSOCKET_DISCONNECTED,
   SEND_REQUEST_OK,
   SEND_REQUEST_FAIL,
-  REQUEST_MESSAGE,
+  WEBSOCKET_MESSAGE_FROM_SERVER,
 } from './constants';
 
 export function connectWebsocket(url, onOpen, onMessage, onClose) {
@@ -68,9 +68,9 @@ export function sendRequestFail(request_id) {
   }
 }
 
-export function requestMessage(message) {
+export function messageFromServer(message) {
   return {
-    type: REQUEST_MESSAGE,
+    type: WEBSOCKET_MESSAGE_FROM_SERVER,
     message,
   }
 }

--- a/frontend/src/containers/WebsocketConnection/constants.js
+++ b/frontend/src/containers/WebsocketConnection/constants.js
@@ -6,6 +6,6 @@ export const SEND_REQUEST = 'luminis/WebsocketConnection/SEND_REQUEST';
 // Parts of the new API (not yet implemented)
 export const SEND_REQUEST_OK = 'luminis/WebsocketConnection/SEND_REQUEST_OK'
 export const SEND_REQUEST_FAIL = 'luminis/WebsocketConnection/SEND_REQUEST_FAIL'
-export const REQUEST_MESSAGE = 'luminis/WebsocketConnection/REQUEST_MESSAGE'
+export const WEBSOCKET_MESSAGE_FROM_SERVER = 'luminis/WebsocketConnection/WEBSOCKET_MESSAGE_FROM_SERVER'
 export const WEBSOCKET_CONNECTED = 'luminis/WebsocketConnection/WEBSOCKET_CONNECTED'
 export const WEBSOCKET_DISCONNECTED = 'luminis/WebsocketConnection/WEBSOCKET_DISCONNECTED'

--- a/frontend/src/containers/WebsocketConnection/constants.js
+++ b/frontend/src/containers/WebsocketConnection/constants.js
@@ -2,3 +2,10 @@ export const CONNECT_WEBSOCKET = 'luminis/WebsocketConnection/CONNECT_WEBSOCKET'
 export const PROCESS_DATA = 'luminis/WebsocketConnection/PROCESS_DATA';
 export const SAVE_WEBSOCKET = 'luminis/WebsocketConnection/SAVE_WEBSOCKET';
 export const SEND_REQUEST = 'luminis/WebsocketConnection/SEND_REQUEST';
+
+// Parts of the new API (not yet implemented)
+export const SEND_REQUEST_OK = 'luminis/WebsocketConnection/SEND_REQUEST_OK'
+export const SEND_REQUEST_FAIL = 'luminis/WebsocketConnection/SEND_REQUEST_FAIL'
+export const REQUEST_MESSAGE = 'luminis/WebsocketConnection/REQUEST_MESSAGE'
+export const WEBSOCKET_CONNECTED = 'luminis/WebsocketConnection/WEBSOCKET_CONNECTED'
+export const WEBSOCKET_DISCONNECTED = 'luminis/WebsocketConnection/WEBSOCKET_DISCONNECTED'


### PR DESCRIPTION
It is part of the new API that implements communication
between WebsocketConnection and other components. New API
will assume that messages from WebsocketConnection are atomic,
i. e. one message is an answer for one request (opposing to earlier
design that sent answers for multiple requests). Some placeholders
were also added to WebsocketConnection.

Tests can be run by `npm test` and coverage tests by `npm test -- --coverage`.
Currently RequestManager coverage is 100%.