### PR TITLE
NodePage: Show live data

### DIFF
--- a/frontend/src/containers/NodePage/index.js
+++ b/frontend/src/containers/NodePage/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import MediaQuery from 'react-responsive';
 import { connect } from 'react-redux';
+import { Map, fromJS } from 'immutable'
 
 import { Card, CardTitle, CardText } from 'material-ui/Card';
 import { List, ListItem } from 'material-ui/List';
@@ -18,13 +19,104 @@ import {
 import { drawerChange } from '../App/actions';
 import ChartCard from '../ChartCard/index'
 import {
-  selectShownMeasurements
+  selectShownMeasurements,
 } from './selectors'
 import {
   showMeasurement,
   hideMeasurement,
   changeShownMeasurements,
 } from './actions'
+import {
+  requestNewLiveData,
+  cancelRequest,
+} from '../RequestManager/actions'
+import {
+  selectActiveRequests,
+} from '../RequestManager/selectors'
+import {
+  PENDING_STATE
+} from '../RequestManager/constants'
+
+// Subcomponent of NodePage that renders right toolbar
+class RightBar extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { measurementRequestMap: new Map() }
+    this.updateSubscriptions = this.updateSubscriptions.bind(this)
+  }
+
+  updateSubscriptions(newMeasurementIds, mounting = false) {
+    const nodeId = this.props.params.nodeId
+    // If measurements have changed, we should drop current subscriptions and make new ones
+    if (!newMeasurementIds.equals(this.props.measurementIds) || mounting) {
+      // Drop current subscriptions
+      const subscriptions = this.state.measurementRequestMap
+      let cancelRequestActions = []
+      subscriptions.forEach((requestId, measurementId) => {
+        cancelRequestActions.push(cancelRequest(requestId))
+      })
+      cancelRequestActions.forEach((action) => this.props.dispatch(action))
+
+      // Create new ones
+      let newMeasurementRequestMap = new Map()
+      let subscriptionRequestActions = []
+      newMeasurementIds.forEach((measurementId) => {
+        const subscriptionRequestAction = requestNewLiveData(nodeId, measurementId)
+        newMeasurementRequestMap =
+          newMeasurementRequestMap.set(measurementId, subscriptionRequestAction.message.request_id)
+        subscriptionRequestActions.push(subscriptionRequestAction)
+      })
+      this.setState({ measurementRequestMap: newMeasurementRequestMap })
+      subscriptionRequestActions.forEach((action) => this.props.dispatch(action))
+    }
+  }
+
+  // Subscribe to live data on mount
+  componentWillMount() {
+    this.updateSubscriptions(this.props.measurementIds, true)
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.updateSubscriptions(nextProps.measurementIds)
+  }
+
+  componentWillUnmount() {
+    // Calling updateSubscriptions with empty measurementIds list will result in request cleanup
+    this.updateSubscriptions(fromJS([]))
+  }
+
+  render() {
+    const nodeMetadata = this.props.nodesMetadata.get(this.props.params.nodeId)
+    return (
+      <List>
+        <Subheader>{nodeMetadata.get("name")}</Subheader>
+        {this.props.measurementIds &&
+          this.props.measurementIds.map((id) => {
+            const request =
+              this.props.activeRequests.get(this.state.measurementRequestMap.get(id))
+            let val = null
+            if (request && request.get('state') !== PENDING_STATE) {
+              val = request.get('data').get('value')
+            }
+            return (<ListItem
+              leftCheckbox={
+                <Checkbox
+                  checked={this.props.measurementIdsShown.get(id) === undefined ?
+                    false : this.props.measurementIdsShown.get(id)}
+                  onClick={this.props.measurementIdsShown.get(id) ?
+                    this.props.onHideMeasurement(id) : this.props.onShowMeasurement(id)}
+                />
+              }
+              key={id}
+            >
+              {this.props.measurementNameGetter(id.toString())}
+              {val ? ": " + val : ""}
+            </ListItem>)})
+        }
+      </List>
+    )
+  }
+}
 
 class NodePage extends React.Component {
   componentWillMount() {
@@ -72,26 +164,6 @@ class NodePage extends React.Component {
       )
     }
 
-    const RightBar = (props) => (
-      <List>
-        <Subheader>{nodeMetadata.get("name")}</Subheader>
-        {props.measurementIds &&
-          props.measurementIds.map((id) =>
-            <ListItem
-              leftCheckbox={
-                <Checkbox
-                  checked={this.props.measurementIdsShown.get(id)}
-                  onClick={this.props.measurementIdsShown.get(id) ?
-                    this.props.onHideMeasurement(id) : this.props.onShowMeasurement(id)}
-                />
-              }
-              key={id}
-              primaryText={props.measurementNameGetter(id.toString())}
-            />)
-        }
-      </List>
-    )
-
     return (
       <div>
         <MediaQuery minWidth={1050}>
@@ -121,6 +193,7 @@ const mapDispatchToProps = (dispatch) => {
     onShowMeasurement: (measurementId) => () => dispatch(showMeasurement(measurementId)),
     onHideMeasurement: (measurementId) => () => dispatch(hideMeasurement(measurementId)),
     onChangeShownMeasurements: (measurementIds) => dispatch(changeShownMeasurements(measurementIds)),
+    dispatch,
   }
 }
 
@@ -137,6 +210,7 @@ const mapStateToProps = (state, ownProps) => {
     measurementIds: measurementIds,
     measurementNameGetter: getMeasurementName,
     measurementIdsShown: measurementIdsShown,
+    activeRequests: selectActiveRequests(state),
   }
 }
 


### PR DESCRIPTION
RightBar został wydzielony do oddzielnego komponentu, i korzysta z Reactowych lifecycle callbacków do zamawiania/odświeżania requestów.